### PR TITLE
Fixed prepareValueFormOptions to be public as per AttributeTypeInterface

### DIFF
--- a/AttributeType/CustomOptionMultiSelectType.php
+++ b/AttributeType/CustomOptionMultiSelectType.php
@@ -49,7 +49,7 @@ class CustomOptionMultiSelectType extends OptionMultiSelectType
     /**
      * {@inheritdoc}
      */
-    protected function prepareValueFormOptions(ProductValueInterface $value)
+    public function prepareValueFormOptions(ProductValueInterface $value)
     {
         return [
                 'class' => $this->optionClass,

--- a/AttributeType/CustomOptionSimpleSelectType.php
+++ b/AttributeType/CustomOptionSimpleSelectType.php
@@ -49,7 +49,7 @@ class CustomOptionSimpleSelectType extends OptionSimpleSelectType
     /**
      * {@inheritdoc}
      */
-    protected function prepareValueFormOptions(ProductValueInterface $value)
+    public function prepareValueFormOptions(ProductValueInterface $value)
     {
         return [
                 'class' => $this->optionClass


### PR DESCRIPTION
This fixes the prepareValueFormOptions to be public as per AttributeTypeInterface
