### PR TITLE
Prepare the 1.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 php:
-    - "5.4"
-    - "5.5"
     - "5.6"
+    - "7.0"
 
 # Allow to use container infrastructure
 sudo: false

--- a/Action/QuickExportAction.php
+++ b/Action/QuickExportAction.php
@@ -80,10 +80,9 @@ class QuickExportAction extends AbstractAction
             );
         }
 
-        $rawConfiguration = [
-            'reference_data' => $this->configuration->getEntityClass(),
-            'ids'            => $this->massActionDispatcher->dispatch($request),
-        ];
+        $rawConfiguration = $jobInstance->getRawParameters();
+        $rawConfiguration['reference_data'] = $this->configuration->getEntityClass();
+        $rawConfiguration['ids'] = $this->massActionDispatcher->dispatch($request);
 
         $this->jobLauncher->launch($jobInstance, $this->getUser(), $rawConfiguration);
 

--- a/Action/QuickExportAction.php
+++ b/Action/QuickExportAction.php
@@ -80,14 +80,10 @@ class QuickExportAction extends AbstractAction
             );
         }
 
-        $rawConfiguration = addslashes(
-            json_encode(
-                [
-                    'reference_data' => $this->configuration->getEntityClass(),
-                    'ids'            => $this->massActionDispatcher->dispatch($request),
-                ]
-            )
-        );
+        $rawConfiguration = [
+            'reference_data' => $this->configuration->getEntityClass(),
+            'ids'            => $this->massActionDispatcher->dispatch($request),
+        ];
 
         $this->jobLauncher->launch($jobInstance, $this->getUser(), $rawConfiguration);
 

--- a/DependencyInjection/PimCustomEntityExtension.php
+++ b/DependencyInjection/PimCustomEntityExtension.php
@@ -30,5 +30,7 @@ class PimCustomEntityExtension extends Extension
         $loader->load('update_guessers.yml');
         $loader->load('form_types.yml');
         $loader->load('controllers.yml');
+        $loader->load('jobs.yml');
+        $loader->load('steps.yml');
     }
 }

--- a/MassEditConnector/JobParameters/ConstraintCollectionProvider/QuickCsvExport.php
+++ b/MassEditConnector/JobParameters/ConstraintCollectionProvider/QuickCsvExport.php
@@ -9,6 +9,8 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 
 /**
+ * Job constraint for Quick Export in CSV
+ * 
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/MassEditConnector/JobParameters/ConstraintCollectionProvider/QuickCsvExport.php
+++ b/MassEditConnector/JobParameters/ConstraintCollectionProvider/QuickCsvExport.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Pim\Bundle\CustomEntityBundle\MassEditConnector\JobParameters\ConstraintCollectionProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
+use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotNull;
+
+/**
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class QuickCsvExport implements ConstraintCollectionProviderInterface
+{
+    /** @var ConstraintCollectionProviderInterface */
+    protected $simpleProvider;
+
+    /** @var array */
+    protected $supportedJobNames;
+
+    /**
+     * @param ConstraintCollectionProviderInterface $simpleProvider
+     * @param array                                 $supportedJobNames
+     */
+    public function __construct(ConstraintCollectionProviderInterface $simpleProvider, array $supportedJobNames)
+    {
+        $this->simpleProvider = $simpleProvider;
+        $this->supportedJobNames = $supportedJobNames;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConstraintCollection()
+    {
+        $baseConstraint = $this->simpleProvider->getConstraintCollection();
+        $constraintFields = $baseConstraint->fields;
+        $constraintFields['reference_data'] = new NotBlank(['groups' => 'Execution']);
+        $constraintFields['ids'] = new NotNull(['groups' => 'Execution']);
+
+        return new Collection(['fields' => $constraintFields]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(JobInterface $job)
+    {
+        return in_array($job->getName(), $this->supportedJobNames);
+    }
+}

--- a/MassEditConnector/JobParameters/DefaultValuesProvider/QuickCsvExport.php
+++ b/MassEditConnector/JobParameters/DefaultValuesProvider/QuickCsvExport.php
@@ -6,6 +6,8 @@ use Akeneo\Component\Batch\Job\JobInterface;
 use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
 
 /**
+ * Default values provider for the quick export csv
+ * 
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)

--- a/MassEditConnector/JobParameters/DefaultValuesProvider/QuickCsvExport.php
+++ b/MassEditConnector/JobParameters/DefaultValuesProvider/QuickCsvExport.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Pim\Bundle\CustomEntityBundle\MassEditConnector\JobParameters\DefaultValuesProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
+
+/**
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class QuickCsvExport implements DefaultValuesProviderInterface
+{
+    /** @var DefaultValuesProviderInterface $simpleProvider */
+    protected $simpleProvider;
+
+    /** @var array */
+    protected $supportedJobNames;
+
+    /**
+     * @param DefaultValuesProviderInterface $simpleProvider
+     * @param array                          $supportedJobNames
+     */
+    public function __construct(DefaultValuesProviderInterface $simpleProvider, array $supportedJobNames)
+    {
+        $this->simpleProvider = $simpleProvider;
+        $this->supportedJobNames = $supportedJobNames;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultValues()
+    {
+        $defaultValues = $this->simpleProvider->getDefaultValues();
+        $defaultValues['reference_data'] = null;
+        $defaultValues['ids'] = null;
+
+        return $defaultValues;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(JobInterface $job)
+    {
+        return in_array($job->getName(), $this->supportedJobNames);
+    }
+}

--- a/MassEditConnector/Processor/ReferenceDataToFlatArrayProcessor.php
+++ b/MassEditConnector/Processor/ReferenceDataToFlatArrayProcessor.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\CustomEntityBundle\MassEditConnector\Processor;
 
 use Pim\Bundle\EnrichBundle\Connector\Processor\AbstractProcessor;
-use Pim\Component\Connector\Repository\JobConfigurationRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -17,15 +16,10 @@ class ReferenceDataToFlatArrayProcessor extends AbstractProcessor
     protected $normalizer;
 
     /**
-     * @param JobConfigurationRepositoryInterface $jobConfigurationRepo
      * @param NormalizerInterface                 $normalizer
      */
-    public function __construct(
-        JobConfigurationRepositoryInterface $jobConfigurationRepo,
-        NormalizerInterface $normalizer
-    ) {
-        parent::__construct($jobConfigurationRepo);
-
+    public function __construct(NormalizerInterface $normalizer)
+    {
         $this->normalizer = $normalizer;
     }
 

--- a/MassEditConnector/Writer/ReferenceDataWriter.php
+++ b/MassEditConnector/Writer/ReferenceDataWriter.php
@@ -2,11 +2,11 @@
 
 namespace Pim\Bundle\CustomEntityBundle\MassEditConnector\Writer;
 
-use Pim\Bundle\BaseConnectorBundle\Writer\File\CsvWriter;
+use Pim\Component\Connector\Writer\File\Csv\Writer;
 
 /**
  * @author Romain Monceau <romain@akeneo.com>
  */
-class ReferenceDataWriter extends CsvWriter
+class ReferenceDataWriter extends Writer
 {
 }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For more information, please see http://docs.akeneo.com/
 
 | CustomEntityBundle   | Akeneo PIM Community Edition |
 |:--------------------:|:----------------------------:|
+| v1.8.*               | v1.6.*                       |
 | v1.7.*               | v1.5.*                       |
 | v1.6.*               | v1.4.*                       |
 | v1.5.0-RC1           | v1.3.*                       |

--- a/Resources/config/actions.yml
+++ b/Resources/config/actions.yml
@@ -77,7 +77,7 @@ services:
         arguments:
             - @pim_datagrid.extension.mass_action.dispatcher
             - @pim_import_export.repository.job_instance
-            - @pim_connector.launcher.simple_job_launcher
+            - @akeneo_batch.launcher.simple_job_launcher
             - @security.token_storage
 
     pim_custom_entity.action.create:

--- a/Resources/config/jobs.yml
+++ b/Resources/config/jobs.yml
@@ -22,7 +22,7 @@ services:
         arguments:
             - '@pim_connector.job.job_parameters.default_values_provider.simple_csv_export'
             -
-                - 'reference_data_quick_export'
+                - '%pim_custom_entity.job_name.reference_data_quick_export%'
         tags:
             - { name: akeneo_batch.job.job_parameters.default_values_provider }
 
@@ -32,6 +32,6 @@ services:
         arguments:
             - '@pim_connector.job.job_parameters.constraint_collection_provider.simple_csv_export'
             -
-                - 'reference_data_quick_export'
+                - '%pim_custom_entity.job_name.reference_data_quick_export%'
         tags:
             - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }

--- a/Resources/config/jobs.yml
+++ b/Resources/config/jobs.yml
@@ -1,0 +1,37 @@
+parameters:
+    pim_custom_entity.connector_name.csv: 'Akeneo Mass Edit Connector'
+    pim_custom_entity.job_name.reference_data_quick_export: 'reference_data_quick_export'
+    pim_custom_entity.job.job_parameters.default_values_provider.quick_csv_export.class: Pim\Bundle\CustomEntityBundle\MassEditConnector\JobParameters\DefaultValuesProvider\QuickCsvExport
+    pim_custom_entity.job.job_parameters.constraint_collection_provider.quick_csv_export.class: Pim\Bundle\CustomEntityBundle\MassEditConnector\JobParameters\ConstraintCollectionProvider\QuickCsvExport
+
+services:
+    pim_custom_entity.job.reference_data_quick_export:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%pim_custom_entity.job_name.reference_data_quick_export%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@pim_custom_entity.step.csv_product.reference_data_quick_export'
+        tags:
+            - { name: akeneo_batch.job, connector: '%pim_custom_entity.connector_name.csv%', type: '%pim_enrich.job.quick_export_type%' }
+
+
+    pim_custom_entity.connector.job.job_parameters.default_values_provider.reference_data_quick_export:
+        class: '%pim_custom_entity.job.job_parameters.default_values_provider.quick_csv_export.class%'
+        arguments:
+            - '@pim_connector.job.job_parameters.default_values_provider.simple_csv_export'
+            -
+                - 'reference_data_quick_export'
+        tags:
+            - { name: akeneo_batch.job.job_parameters.default_values_provider }
+
+
+    pim_custom_entity.connector.job.job_parameters.constraint_collection_provider.reference_data_quick_export:
+        class: '%pim_custom_entity.job.job_parameters.constraint_collection_provider.quick_csv_export.class%'
+        arguments:
+            - '@pim_connector.job.job_parameters.constraint_collection_provider.simple_csv_export'
+            -
+                - 'reference_data_quick_export'
+        tags:
+            - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }

--- a/Resources/config/mass_edit_connector.yml
+++ b/Resources/config/mass_edit_connector.yml
@@ -7,16 +7,14 @@ services:
     pim_custom_entity.mass_edit_connector.reader.reference_data:
         class: %pim_custom_entity.mass_edit_connector.reader.reference_data.class%
         arguments:
-            - @pim_connector.repository.job_configuration
             - @doctrine.orm.entity_manager
             - @pim_reference_data.registry
 
     pim_custom_entity.mass_edit_connector.processor.reference_data_to_flat_array:
         class: %pim_custom_entity.mass_edit_connector.processor.reference_data_to_flat_array.class%
         arguments:
-            - @pim_connector.repository.job_configuration
             - @pim_serializer
 
     pim_custom_entity.mass_edit_connector.processor.reference_data_writer:
         class: %pim_custom_entity.mass_edit_connector.writer.reference_data.class%
-        parent: pim_base_connector.writer.file.csv
+        parent: pim_connector.writer.file.csv

--- a/Resources/config/steps.yml
+++ b/Resources/config/steps.yml
@@ -1,5 +1,3 @@
-parameters: ~
-
 services:
     pim_custom_entity.step.csv_product.reference_data_quick_export:
         class: '%pim_connector.step.item_step.class%'

--- a/Resources/config/steps.yml
+++ b/Resources/config/steps.yml
@@ -1,0 +1,13 @@
+parameters: ~
+
+services:
+    pim_custom_entity.step.csv_product.reference_data_quick_export:
+        class: '%pim_connector.step.item_step.class%'
+        arguments:
+            - 'quick_export'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_custom_entity.mass_edit_connector.reader.reference_data'
+            - '@pim_custom_entity.mass_edit_connector.processor.reference_data_to_flat_array'
+            - '@pim_custom_entity.mass_edit_connector.processor.reference_data_writer'
+            - 100

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,14 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "akeneo/pim-community-dev": "1.5.*"
+        "akeneo/pim-community-dev": "1.6.x-dev@dev"
     },
     "require-dev": {
-        "phpspec/phpspec": "2.1.*",
+        "phpspec/phpspec": "3.0.0",
         "squizlabs/php_codesniffer": "2.3.*",
         "phpmd/phpmd": "2.3.*",
         "friendsofphp/php-cs-fixer": "@stable",
-        "henrikbjorn/phpspec-code-coverage": "1.0.*",
-        "doctrine/migrations": "1.0.0-alpha3@alpha"
+        "henrikbjorn/phpspec-code-coverage": "3.0.1"
     },
     "config": {
         "bin-dir": "bin"
@@ -41,7 +40,7 @@
     "target-dir": "Pim/Bundle/CustomEntityBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7.x-dev"
+            "dev-master": "1.8.x-dev"
         }
     }
 }

--- a/spec/Pim/Bundle/CustomEntityBundle/Action/ActionFactorySpec.php
+++ b/spec/Pim/Bundle/CustomEntityBundle/Action/ActionFactorySpec.php
@@ -11,8 +11,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ActionFactorySpec extends ObjectBehavior
 {
     public function let(
-        Registry $confRegistry,
-        ContainerInterface $container
+        ContainerInterface $container,
+        Registry $confRegistry
     ) {
         $this->beConstructedWith($container, $confRegistry);
     }

--- a/spec/Pim/Bundle/CustomEntityBundle/Action/QuickExportActionSpec.php
+++ b/spec/Pim/Bundle/CustomEntityBundle/Action/QuickExportActionSpec.php
@@ -137,14 +137,10 @@ class QuickExportActionSpec extends ObjectBehavior
             ->getActionOptions('quick_export')
             ->willReturn(['job_profile' => 'csv_reference_data_quick_export']);
 
-        $rawConfig = addslashes(
-            json_encode(
-                [
-                    'reference_data' => 'entity_class',
-                    'ids'            => [2, 5]
-                ]
-            )
-        );
+        $rawConfig = [
+            'reference_data' => 'entity_class',
+            'ids'            => [2, 5]
+        ];
 
         $jobLauncher->launch($jobInstance, $user, $rawConfig)->shouldBeCalled();
 


### PR DESCRIPTION
PIM CE 1.6 & EE 1.6 compatibility,

The 1.5 compatibility is now ensured in 1.7 branch.

With this PR master become 1.8 branch.

TODO:
 - [x] migrate the bundle to 1.6
 - [x] test in a EE 1.6 with the demo bundle provided here https://github.com/akeneo-labs/custom-entity-demo (symlink to the CustomBundle and looks incompatible with the pim dev AcmeAppBundle)
 - [x] review from markeplace team