### PR TITLE
Fixed pim requirement version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ For more information, please see http://docs.akeneo.com/
 
 | CustomEntityBundle   | Akeneo PIM Community Edition |
 |:--------------------:|:----------------------------:|
-| v1.9.*               | v1.7.*                       |
+| v1.10.*              | v1.7.*                       |
+| v1.9.*               | v1.6.*                       |
 | v1.8.*               | v1.6.*                       |
 | v1.7.*               | v1.5.*                       |
 | v1.6.*               | v1.4.*                       |
@@ -25,7 +26,7 @@ For more information, please see http://docs.akeneo.com/
 You can install this bundle with composer (see requirements section):
 
 ```bash
-    php composer.phar require akeneo-labs/custom-entity-bundle:1.9.*
+    php composer.phar require akeneo-labs/custom-entity-bundle:1.10.*
 ```
 
 Then add the following lines **at the end** of your app/config/routing.yml :


### PR DESCRIPTION
Hello there!

Congrats for the PIM v1.7 release, I guess the README hasn't been correctly modified here since then!

The bundle in version 1.9 depends on pim-community-dev v1.6 and not v1.7 as states the doc today.