### PR TITLE
Added Akeneo EE support

### DIFF
--- a/Controller/EnterpriseAjaxOptionController.php
+++ b/Controller/EnterpriseAjaxOptionController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Pim\Bundle\CustomEntityBundle\Controller;
+
+use PimEnterprise\Bundle\UIBundle\Controller\AjaxOptionController as BaseAjaxOptionController;
+use Pim\Component\ReferenceData\Repository\ReferenceDataRepositoryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Overridden because the data locale is not taken into account in the AjaxOptionController
+ *
+ * @author Romain Monceau <romain@akeneo.com>
+ */
+class EnterpriseAjaxOptionController extends BaseAjaxOptionController
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function listAction(Request $request)
+    {
+        $query = $request->query;
+        $repository = $this->doctrine->getRepository($query->get('class'));
+
+        if ($repository instanceof ReferenceDataRepositoryInterface) {
+            $options = $query->get('options', []) + ['dataLocale' => $query->get('dataLocale')];
+
+            $choices = ['results' => $repository->findBySearch($query->get('search'), $options)];
+
+            return new JsonResponse($choices);
+        }
+
+        return parent::listAction($request);
+    }
+}

--- a/Resources/config/controllers.yml
+++ b/Resources/config/controllers.yml
@@ -1,5 +1,6 @@
 parameters:
     pim_ui.controller.ajax_option.class: Pim\Bundle\CustomEntityBundle\Controller\AjaxOptionController
+    pimee_ui.controller.ajax_option.class: Pim\Bundle\CustomEntityBundle\Controller\EnterpriseAjaxOptionController
     pim_custom_entity.rest_controller.class: Pim\Bundle\CustomEntityBundle\Controller\RestController
 
 services:


### PR DESCRIPTION
Akeneo EE support was missing, the options list did not appear properly in the PEF due to a 500 error in ajax requests (`dataLocale` option was not transmitted to the reference data repository)