### PR TITLE
#111: Use get_class($this) instead of __CLASS__ in AbstractCustomEntity

### DIFF
--- a/Action/Rest/AbstractRestAction.php
+++ b/Action/Rest/AbstractRestAction.php
@@ -154,7 +154,7 @@ abstract class AbstractRestAction implements ActionInterface
     {
         $manager = $this->getManager();
         $entityName = $this->configuration->getName();
-        $editFormExtension = $this->configuration->getOptions()['edit_fom_extension'];
+        $editFormExtension = $this->configuration->getOptions()['edit_form_extension'];
         $context = [
             'customEntityName' => $entityName,
             'form'             => $editFormExtension,

--- a/Entity/AbstractCustomEntity.php
+++ b/Entity/AbstractCustomEntity.php
@@ -65,7 +65,7 @@ abstract class AbstractCustomEntity extends AbstractReferenceData
      */
     public function getCustomEntityName(): string
     {
-        return strtolower(join('', array_slice(explode('\\', __CLASS__), -1)));
+        return strtolower(join('', array_slice(explode('\\', get_class($this)), -1)));
     }
 
     /**


### PR DESCRIPTION
Fixes #111 and #110 