### PR TITLE
Added a custom-entity dropdown list for single and multi select

### DIFF
--- a/Action/Rest/GetAllAction.php
+++ b/Action/Rest/GetAllAction.php
@@ -7,7 +7,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author    Kevin Rademan <kevin@versa.co.za>
- * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class GetAllAction extends AbstractRestAction

--- a/Action/Rest/GetAllAction.php
+++ b/Action/Rest/GetAllAction.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Get list of custom entities
- * 
+ *
  * @author    Kevin Rademan <kevin@versa.co.za>
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -23,7 +23,7 @@ class GetAllAction extends AbstractRestAction
         );
 
         $normalizedEntities = [];
-        foreach($entities as $entity) {
+        foreach ($entities as $entity) {
             $normalizedEntities[] = $this->normalize($entity);
         }
 

--- a/Action/Rest/GetAllAction.php
+++ b/Action/Rest/GetAllAction.php
@@ -6,6 +6,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
+ * Get list of custom entities
+ * 
  * @author    Kevin Rademan <kevin@versa.co.za>
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/Action/Rest/GetAllAction.php
+++ b/Action/Rest/GetAllAction.php
@@ -6,7 +6,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @author    JM Leroux <jean-marie.leroux@akeneo.com>
+ * @author    Kevin Rademan <kevin@versa.co.za>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */

--- a/Action/Rest/GetAllAction.php
+++ b/Action/Rest/GetAllAction.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Pim\Bundle\CustomEntityBundle\Action\Rest;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author    JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetAllAction extends AbstractRestAction
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function doExecute(Request $request): JsonResponse
+    {
+        $entities = $this->getManager()->findAll(
+            $this->configuration->getEntityClass()
+        );
+
+        $normalizedEntities = [];
+        foreach($entities as $entity) {
+            $normalizedEntities[] = $this->normalize($entity);
+        }
+
+        return new JsonResponse($normalizedEntities);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return 'rest_getall';
+    }
+}

--- a/Action/Rest/UpdateAction.php
+++ b/Action/Rest/UpdateAction.php
@@ -55,8 +55,9 @@ class UpdateAction extends AbstractRestAction
         }
 
         $manager->save($entity);
+        $normalized = $this->normalize($entity);
 
-        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+        return new JsonResponse($normalized);
     }
 
     /**

--- a/Configuration/Configuration.php
+++ b/Configuration/Configuration.php
@@ -120,7 +120,7 @@ class Configuration implements ConfigurationInterface
     {
         $resolver->setDefaults([
             'manager'            => 'default',
-            'edit_fom_extension' => null,
+            'edit_form_extension' => null,
         ]);
         $event = new ConfigurationEvent($this, $resolver);
         $this->eventDispatcher->dispatch(ConfigurationEvents::CONFIGURE, $event);

--- a/Manager/Manager.php
+++ b/Manager/Manager.php
@@ -74,6 +74,14 @@ class Manager implements ManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function findAll($entityClass)
+    {
+        return $this->em->getRepository($entityClass)->findAll();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function update($entity, array $normalizedData): void
     {
         $this->updater->update($entity, $normalizedData);

--- a/Manager/Manager.php
+++ b/Manager/Manager.php
@@ -74,7 +74,7 @@ class Manager implements ManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function findAll($entityClass)
+    public function findAll($entityClass) : array
     {
         return $this->em->getRepository($entityClass)->findAll();
     }

--- a/Manager/ManagerInterface.php
+++ b/Manager/ManagerInterface.php
@@ -35,6 +35,17 @@ interface ManagerInterface
      */
     public function find($entityClass, $id, array $options = []);
 
+
+    /**
+     * Find all entities, returns empty array if none are found
+     *
+     * @param string $entityClass
+     *
+     * @return array
+     */
+    public function findAll($entityClass);
+
+
     /**
      * Saves the entity
      *

--- a/Manager/ManagerInterface.php
+++ b/Manager/ManagerInterface.php
@@ -43,7 +43,7 @@ interface ManagerInterface
      *
      * @return array
      */
-    public function findAll($entityClass);
+    public function findAll($entityClass) : array;
 
 
     /**

--- a/Normalizer/CustomEntityNormalizer.php
+++ b/Normalizer/CustomEntityNormalizer.php
@@ -44,9 +44,13 @@ class CustomEntityNormalizer implements NormalizerInterface
         $normalizedEntity = $this->pimSerializer->normalize($entity, 'standard', $context);
 
         $meta = [
-            'id'               => $entity->getId(),
-            'customEntityName' => $context['customEntityName'],
-            'form'             => $context['form'],
+            // Seems the upstream pim introduced some verioning for the javascript 
+            // assets. Not sure how to implement this correct and dont have the time
+            // to investigate this now. Hardcoding the version for now
+            'structure_version' => '2',
+            'id'                => $entity->getId(),
+            'customEntityName'  => $context['customEntityName'],
+            'form'              => $context['form'],
         ];
 
         return [

--- a/Normalizer/CustomEntityNormalizer.php
+++ b/Normalizer/CustomEntityNormalizer.php
@@ -44,9 +44,10 @@ class CustomEntityNormalizer implements NormalizerInterface
         $normalizedEntity = $this->pimSerializer->normalize($entity, 'standard', $context);
 
         $meta = [
-            // Seems the upstream pim introduced some verioning for the javascript 
-            // assets. Not sure how to implement this correct and dont have the time
-            // to investigate this now. Hardcoding the version for now
+            // Seems the upstream pim introduced some versioning for the javascript assets.
+            // Not sure how to implement this correct and dont have the time to investigate this now.
+            // Hardcoding the version for now
+            // TODO: remove hardcoding
             'structure_version' => '2',
             'id'                => $entity->getId(),
             'customEntityName'  => $context['customEntityName'],

--- a/Resources/config/actions.yml
+++ b/Resources/config/actions.yml
@@ -2,10 +2,11 @@ parameters:
     pim_custom_entity.action.factory.class:      Pim\Bundle\CustomEntityBundle\Action\ActionFactory
     pim_custom_entity.action.quick_export.class: Pim\Bundle\CustomEntityBundle\Action\QuickExportAction
 
-    pim_custom_entity.action.rest.create.class: Pim\Bundle\CustomEntityBundle\Action\Rest\CreateAction
-    pim_custom_entity.action.rest.delete.class: Pim\Bundle\CustomEntityBundle\Action\Rest\DeleteAction
-    pim_custom_entity.action.rest.get.class:    Pim\Bundle\CustomEntityBundle\Action\Rest\GetAction
-    pim_custom_entity.action.rest.update.class: Pim\Bundle\CustomEntityBundle\Action\Rest\UpdateAction
+    pim_custom_entity.action.rest.create.class:  Pim\Bundle\CustomEntityBundle\Action\Rest\CreateAction
+    pim_custom_entity.action.rest.delete.class:  Pim\Bundle\CustomEntityBundle\Action\Rest\DeleteAction
+    pim_custom_entity.action.rest.get.class:     Pim\Bundle\CustomEntityBundle\Action\Rest\GetAction
+    pim_custom_entity.action.rest.getall.class:    Pim\Bundle\CustomEntityBundle\Action\Rest\GetAllAction
+    pim_custom_entity.action.rest.update.class:  Pim\Bundle\CustomEntityBundle\Action\Rest\UpdateAction
 
 services:
     pim_custom_entity.action.factory:
@@ -50,6 +51,14 @@ services:
 
     pim_custom_entity.action.rest.get:
         class: '%pim_custom_entity.action.rest.get.class%'
+        shared: false
+        arguments:
+            - '@pim_custom_entity.action.factory'
+            - '@pim_custom_entity.action_event_manager'
+            - '@pim_custom_entity.manager.registry'
+
+    pim_custom_entity.action.rest.getall:
+        class: '%pim_custom_entity.action.rest.getall.class%'
         shared: false
         arguments:
             - '@pim_custom_entity.action.factory'

--- a/Resources/config/custom_entities.yml
+++ b/Resources/config/custom_entities.yml
@@ -7,6 +7,9 @@ custom_entities:
             rest_get:
                 service: pim_custom_entity.action.rest.get
                 enabled: true
+            rest_getall:
+                service: pim_custom_entity.action.rest.getall
+                enabled: true
             rest_delete:
                 service: pim_custom_entity.action.rest.delete
                 enabled: true

--- a/Resources/config/requirejs.yml
+++ b/Resources/config/requirejs.yml
@@ -1,6 +1,7 @@
 config:
     paths:
         custom_entity/field/select2: pimcustomentity/js/field/select2
+        custom_entity/field/custom-entity-select: pimcustomentity/js/field/custom-entity-select
         custom_entity/form/creation/modal: pimcustomentity/js/form/creation/modal
         custom_entity/form/common/entity-saver: pimcustomentity/js/form/common/entity-saver
         custom_entity/form/common/save-form: pimcustomentity/js/form/common/save-form
@@ -20,6 +21,7 @@ config:
                         urls:
                             list: pim_customentity_rest_list
                             get: pim_customentity_rest_get
+                            getall: pim_customentity_rest_get
 
         pim/controller-registry:
             controllers:

--- a/Resources/config/requirejs.yml
+++ b/Resources/config/requirejs.yml
@@ -21,7 +21,7 @@ config:
                         urls:
                             list: pim_customentity_rest_list
                             get: pim_customentity_rest_get
-                            getall: pim_customentity_rest_get
+                            getall: pim_customentity_rest_getall
 
         pim/controller-registry:
             controllers:

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -30,6 +30,13 @@ pim_customentity_rest_get:
         actionType: rest_get
     methods: [GET]
 
+pim_customentity_rest_getall:
+    path: /rest/{customEntityName}
+    defaults:
+        _controller: pim_custom_entity.controller:executeAction
+        actionType: rest_getall
+    methods: [GET]
+
 pim_customentity_rest_edit:
     path: /rest/{customEntityName}/{id}/edit
     defaults:

--- a/Resources/public/js/controller/custom_entity-edit.js
+++ b/Resources/public/js/controller/custom_entity-edit.js
@@ -20,19 +20,19 @@ define(
                         return createForm.call(
                             this,
                             this.$el,
-                            normalizedEntity.data,
+                            normalizedEntity,
                             normalizedEntity.meta.form
                         );
                     });
 
-                function createForm(domElement, entity, formExtension) {
+                function createForm(domElement, normalizedEntity, formExtension) {
                     return FormBuilder.build(formExtension)
                         .then((form) => {
                             this.on('pim:controller:can-leave', function (event) {
                                 form.trigger('pim_enrich:form:can-leave', event);
                             });
-                            form.setData(entity);
-                            form.trigger('pim_enrich:form:entity:post_fetch', entity);
+                            form.setData(normalizedEntity.data);
+                            form.trigger('pim_enrich:form:entity:post_fetch', normalizedEntity);
                             form.setElement(domElement).render();
 
                             return form;

--- a/Resources/public/js/controller/custom_entity-edit.js
+++ b/Resources/public/js/controller/custom_entity-edit.js
@@ -17,27 +17,20 @@ define(
                 return FetcherRegistry.getFetcher('custom_entity')
                     .fetch(route.params.customEntityName, route.params.id, {cached: false})
                     .then((normalizedEntity) => {
-                        return createForm.call(
-                            this,
-                            this.$el,
-                            normalizedEntity,
-                            normalizedEntity.meta.form
-                        );
-                    });
+                        const formExtension = normalizedEntity.meta.form;
 
-                function createForm(domElement, normalizedEntity, formExtension) {
-                    return FormBuilder.build(formExtension)
-                        .then((form) => {
-                            this.on('pim:controller:can-leave', function (event) {
-                                form.trigger('pim_enrich:form:can-leave', event);
+                        return FormBuilder.build(formExtension)
+                            .then((form) => {
+                                this.on('pim:controller:can-leave', function (event) {
+                                    form.trigger('pim_enrich:form:can-leave', event);
+                                });
+                                form.setData(normalizedEntity.data);
+                                form.trigger('pim_enrich:form:entity:post_fetch', normalizedEntity);
+                                form.setElement(this.$el).render();
+
+                                return form;
                             });
-                            form.setData(normalizedEntity.data);
-                            form.trigger('pim_enrich:form:entity:post_fetch', normalizedEntity);
-                            form.setElement(domElement).render();
-
-                            return form;
-                        });
-                }
+                    });
             }
         });
     }

--- a/Resources/public/js/fetcher/custom_entity-fetcher.js
+++ b/Resources/public/js/fetcher/custom_entity-fetcher.js
@@ -51,6 +51,33 @@ define(
                 }
 
                 return this.entityPromises[identifier];
+            },
+
+            /**
+             * Fetch all elements
+             *
+             * @param {string} customEntityName
+             * @param {Object} options
+             *
+             * @return {Promise}
+             */
+            fetchAllByType: function (customEntityName) {
+                let deferred = $.Deferred();
+                $.getJSON(
+                    Routing.generate(
+                        this.options.urls.getall,
+                        _.extend({
+                            customEntityName: customEntityName
+                        })
+                    )
+                ).then(_.identity).done(function (entities) {
+                    deferred.resolve(entities);
+                }).fail(function (promise, status, error) {
+                    console.error('Error fetching: ', error);
+                    return deferred.reject(promise);
+                });
+
+                return deferred.promise();
             }
         });
     });

--- a/Resources/public/js/field/custom-entity-select.js
+++ b/Resources/public/js/field/custom-entity-select.js
@@ -3,8 +3,7 @@
 /**
  * Reference data select field
  *
- * @author    Anaël CHARDAN <anael.chardan@akeneo.com>
- * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @author    Kevin Rademan <kevin@versa.co.za>
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 define(

--- a/Resources/public/js/field/custom-entity-select.js
+++ b/Resources/public/js/field/custom-entity-select.js
@@ -14,27 +14,17 @@ define(
         'pim/fetcher-registry',
         'pim/form/common/fields/select'
     ],
-    function (
-        $,
-        _,
-        __,
-        FetcherRegistry,
-        SelectField,
-    ) {
+    function ($, _, __, FetcherRegistry, SelectField ) {
         return SelectField.extend({
             /**
              * {@inherit}
              */
-            configure: function () {
+            configure() {
                 let fetcher = null;
-                if(this.config.isCustomEntity) {
-                    fetcher = FetcherRegistry
-                                .getFetcher('custom_entity')
-                                .fetchAllByType(this.config.entityName);
+                if (this.config.isCustomEntity) {
+                    fetcher = FetcherRegistry.getFetcher('custom_entity').fetchAllByType(this.config.entityName);
                 } else {
-                    fetcher = FetcherRegistry
-                                .getFetcher(this.config.entityName)
-                                .fetchAll();
+                    fetcher = FetcherRegistry.getFetcher(this.config.entityName).fetchAll();
                 }
                 return $.when(
                     fetcher,
@@ -50,7 +40,7 @@ define(
                         let choices = {};
                         let nameProp = this.config.choiceNameField;
                         let valueProp = this.config.choiceValueField;
-                        items.forEach(function(item) {
+                        items.forEach(function (item) {
                             let entity = config.isCustomEntity ? item.data : item;
                             choices[entity[nameProp]] = entity[valueProp];
                         });

--- a/Resources/public/js/field/custom-entity-select.js
+++ b/Resources/public/js/field/custom-entity-select.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * Reference data select field
+ *
+ * @author    Anaël CHARDAN <anael.chardan@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define(
+    [
+        'jquery',
+        'underscore',
+        'oro/translator',
+        'pim/fetcher-registry',
+        'pim/form/common/fields/select'
+    ],
+    function (
+        $,
+        _,
+        __,
+        FetcherRegistry,
+        SelectField,
+    ) {
+        return SelectField.extend({
+            /**
+             * {@inherit}
+             */
+            configure: function () {
+                let fetcher = null;
+                if(this.config.isCustomEntity) {
+                    fetcher = FetcherRegistry
+                                .getFetcher('custom_entity')
+                                .fetchAllByType(this.config.entityName);
+                } else {
+                    fetcher = FetcherRegistry
+                                .getFetcher(this.config.entityName)
+                                .fetchAll();
+                }
+                return $.when(
+                    fetcher,
+                    SelectField.prototype.configure.apply(this, arguments)
+                ).then(function (items) {
+                    let config = this.config;
+                    if (_.isEmpty(items)) {
+                        this.config.readOnly = true;
+                        this.config.choices = {
+                            'NO OPTION': __('pim_custom_entity.import.csv.entity_name.no_reference_data')
+                        };
+                    } else {
+                        let choices = {};
+                        let nameProp = this.config.choiceNameField;
+                        let valueProp = this.config.choiceValueField;
+                        items.forEach(function(item) {
+                            let entity = config.isCustomEntity ? item.data : item;
+                            choices[entity[nameProp]] = entity[valueProp];
+                        });
+                        this.config.choices = choices;
+                    }
+                }.bind(this));
+            }
+        });
+    });

--- a/Updater/Updater.php
+++ b/Updater/Updater.php
@@ -132,7 +132,6 @@ class Updater implements ObjectUpdaterInterface
         $classMetadata = $this->getClassMetadata($referenceData);
         
 
-        // \Doctrine\Common\Util\Debug::dump($propertyPath.": " . $classMetadata->isCollectionValuedAssociation($propertyPath) . "\n");
         if (is_subclass_of(
             $associationMapping['targetEntity'],
             'Akeneo\Component\FileStorage\Model\FileInfoInterface'

--- a/Updater/Updater.php
+++ b/Updater/Updater.php
@@ -129,7 +129,10 @@ class Updater implements ObjectUpdaterInterface
     {
         $associationMapping = $this->getAssociationMapping($referenceData, $propertyPath);
         $associationRepo = $this->em->getRepository($associationMapping['targetEntity']);
+        $classMetadata = $this->getClassMetadata($referenceData);
+        
 
+        // \Doctrine\Common\Util\Debug::dump($propertyPath.": " . $classMetadata->isCollectionValuedAssociation($propertyPath) . "\n");
         if (is_subclass_of(
             $associationMapping['targetEntity'],
             'Akeneo\Component\FileStorage\Model\FileInfoInterface'
@@ -153,6 +156,11 @@ class Updater implements ObjectUpdaterInterface
                 }
 
                 $associatedEntity = $this->storer->store($rawFile, FileStorage::CATALOG_STORAGE_ALIAS);
+            }
+        } elseif ($classMetadata->isCollectionValuedAssociation($propertyPath)) {
+            $associatedEntity = [];
+            foreach($value as $entityCode) {
+                $associatedEntity[] = $associationRepo->findOneBy(['code' => $entityCode]);
             }
         } else {
             $associatedEntity = $associationRepo->findOneBy(['code' => $value]);

--- a/Updater/Updater.php
+++ b/Updater/Updater.php
@@ -3,7 +3,6 @@
 namespace Pim\Bundle\CustomEntityBundle\Updater;
 
 use Akeneo\Component\FileStorage\File\FileStorerInterface;
-use Akeneo\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -130,7 +129,6 @@ class Updater implements ObjectUpdaterInterface
         $associationMapping = $this->getAssociationMapping($referenceData, $propertyPath);
         $associationRepo = $this->em->getRepository($associationMapping['targetEntity']);
         $classMetadata = $this->getClassMetadata($referenceData);
-        
 
         if (is_subclass_of(
             $associationMapping['targetEntity'],
@@ -138,10 +136,13 @@ class Updater implements ObjectUpdaterInterface
         )) {
             if (empty($value['filePath'])) {
                 $this->propertyAccessor->setValue($referenceData, $propertyPath, null);
+
                 return;
             }
 
-            $associatedEntity = $associationRepo->findOneBy(['key' => str_replace($this->tmpStorageDir, '', $value['filePath'])]);
+            $associatedEntity = $associationRepo->findOneBy([
+                'key' => str_replace($this->tmpStorageDir, '', $value['filePath']),
+            ]);
 
             if (null === $associatedEntity) {
                 $rawFile = new \SplFileInfo($value['filePath']);
@@ -158,7 +159,7 @@ class Updater implements ObjectUpdaterInterface
             }
         } elseif ($classMetadata->isCollectionValuedAssociation($propertyPath)) {
             $associatedEntity = [];
-            foreach($value as $entityCode) {
+            foreach ($value as $entityCode) {
                 $associatedEntity[] = $associationRepo->findOneBy(['code' => $entityCode]);
             }
         } else {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "akeneo/pim-community-dev": "2.0.*"
+        "akeneo/pim-community-dev": "^2.0.6"
     },
     "require-dev": {
         "phpspec/phpspec": "^3.0",

--- a/docs/examples/CustomBundle/Normalizer/Standard/BrandNormalizer.php
+++ b/docs/examples/CustomBundle/Normalizer/Standard/BrandNormalizer.php
@@ -7,6 +7,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * @author    JM Leroux <jean-marie.leroux@akeneo.com>
+ * @author    Kevin Rademan <kevin.rademan@locafox.de>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
@@ -42,8 +43,10 @@ class BrandNormalizer implements NormalizerInterface
 
         $fabric = $entity->getFabric();
         if (null !== $fabric) {
-            $normalizedFabric = $this->fabricNormalizer->normalize($fabric, 'standard');
-            $normalizedBrand['fabric'] = $normalizedFabric;
+            $normalizedBrand['fabric'] = $fabric->getCode();
+            // Perhaps we should have a seperate normalizer for the dropdown ?
+            // $normalizedFabric = $this->fabricNormalizer->normalize($fabric, 'standard');
+            // $normalizedBrand['fabric'] = $normalizedFabric;
         }
 
         return $normalizedBrand;

--- a/docs/examples/CustomBundle/Resources/config/custom_entities.yml
+++ b/docs/examples/CustomBundle/Resources/config/custom_entities.yml
@@ -2,19 +2,19 @@ custom_entities:
     color:
         entity_class: Acme\Bundle\CustomBundle\Entity\Color
         options:
-            edit_fom_extension: pim-color-edit-form
+            edit_form_extension: pim-color-edit-form
 
     fabric:
         entity_class: Acme\Bundle\CustomBundle\Entity\Fabric
         options:
-            edit_fom_extension: pim-fabric-edit-form
+            edit_form_extension: pim-fabric-edit-form
 
     pictogram:
         entity_class: Acme\Bundle\CustomBundle\Entity\Pictogram
         options:
-            edit_fom_extension: pim-pictogram-edit-form
+            edit_form_extension: pim-pictogram-edit-form
 
     brand:
         entity_class: Acme\Bundle\CustomBundle\Entity\Brand
         options:
-            edit_fom_extension: pim-brand-edit-form
+            edit_form_extension: pim-brand-edit-form

--- a/docs/examples/CustomBundle/Resources/config/form_extensions/brand/edit.yml
+++ b/docs/examples/CustomBundle/Resources/config/form_extensions/brand/edit.yml
@@ -139,3 +139,16 @@ extensions:
             label: acme_custom.brand.field.label.code
             required: true
             readOnly: true
+
+    pim-brand-edit-form-properties-fabric:
+        module: custom_entity/field/custom-entity-select
+        parent: pim-brand-edit-form-properties-common
+        targetZone: content
+        position: 100
+        config:
+            fieldName: fabric
+            choiceNameField: code
+            choiceValueField: name
+            isCustomEntity: true
+            entityName: fabric
+            required: false

--- a/spec/Pim/Bundle/CustomEntityBundle/Normalizer/CustomEntityNormalizerSpec.php
+++ b/spec/Pim/Bundle/CustomEntityBundle/Normalizer/CustomEntityNormalizerSpec.php
@@ -50,9 +50,10 @@ class CustomEntityNormalizerSpec extends ObjectBehavior
         $expected = [
             'data' => $normalizedEntity,
             'meta' => [
-                'id'               => 666,
-                'customEntityName' => 'fooEntity',
-                'form'             => 'foo_form_extension',
+                'structure_version' => '2',
+                'id'                => 666,
+                'customEntityName'  => 'fooEntity',
+                'form'              => 'foo_form_extension',
             ],
         ];
 


### PR DESCRIPTION
* NEW: GetAllAction which can load a list of custom entities
* NEW: custom-entity-select javascript module for the custom dropdown (see usage below)
* IMPROVEMENT: Extended the custom_entity-fetcher.js to allow loading custom entities by type
* IMPROVEMENT: Extended the Updater.php to support  collection value association

New component case by used by adding a form extensions using the yml below

Custom entity that supports single select
```
pim-retailer-edit-form-properties-association:
        module: custom_entity/field/custom-entity-select
        parent: pim-retailer-edit-form-properties-common
        targetZone: content
        position: 270
        config:
            fieldName: association
            choiceNameField: code
            choiceValueField: name
            isCustomEntity: true
            entityName: association
            required: false
```
Custom entity that supports multi select
```
pim-retailer-edit-form-properties-paymenttypes:
        module: custom_entity/field/custom-entity-select
        parent: pim-retailer-edit-form-properties-common
        targetZone: content
        position: 280
        config:
            fieldName: paymentTypes
            choiceNameField: code
            choiceValueField: name
            isCustomEntity: true
            entityName: paymenttype
            required: false
            isMultiple: true
```

Field on a custom entity that refers to a built in akeneo type (special usecase for us)
```
pim-entity-edit-form-properties-attribute:
        module: custom_entity/field/custom-entity-select
        parent: pim-entity-edit-form-properties-common
        targetZone: content
        position: 270
        config:
            fieldName: attribute
            choiceNameField: code
            choiceValueField: name
            isCustomEntity: false
            entityName: attribute
            required: false
```