### PR TITLE
Allow updater to cache several metadata at the same time

### DIFF
--- a/CHANGELOG-1.10.md
+++ b/CHANGELOG-1.10.md
@@ -1,3 +1,9 @@
+#1.10.8
+
+## Improvements
+
+Allow `Pim\Bundle\CustomEntityBundle\Updater\Updater` to cache several class metadata at the same time
+
 # 1.10.7
 
 ## Bug fixes

--- a/Updater/Updater.php
+++ b/Updater/Updater.php
@@ -29,8 +29,8 @@ class Updater implements ObjectUpdaterInterface
     /** @var EntityManagerInterface */
     protected $em;
 
-    /** @var ClassMetadataInfo */
-    protected $classMetadata;
+    /** @var ClassMetadataInfo[] */
+    protected $classMetadata = [];
 
     /**
      * @param PropertyAccessorInterface $propertyAccessor
@@ -145,11 +145,12 @@ class Updater implements ObjectUpdaterInterface
      */
     protected function getClassMetadata(ReferenceDataInterface $referenceData)
     {
-        if (null === $this->classMetadata) {
-            $this->classMetadata = $this->em->getClassMetadata(ClassUtils::getClass($referenceData));
+        $entityName = ClassUtils::getClass($referenceData);
+        if (!isset($this->classMetadata[$entityName]) || null === $this->classMetadata[$entityName]) {
+            $this->classMetadata[$entityName] = $this->em->getClassMetadata($entityName);
         }
 
-        return $this->classMetadata;
+        return $this->classMetadata[$entityName];
     }
 
     /**

--- a/Updater/Updater.php
+++ b/Updater/Updater.php
@@ -146,7 +146,7 @@ class Updater implements ObjectUpdaterInterface
     protected function getClassMetadata(ReferenceDataInterface $referenceData)
     {
         $entityName = ClassUtils::getClass($referenceData);
-        if (!isset($this->classMetadata[$entityName]) || null === $this->classMetadata[$entityName]) {
+        if (!isset($this->classMetadata[$entityName])) {
             $this->classMetadata[$entityName] = $this->em->getClassMetadata($entityName);
         }
 


### PR DESCRIPTION
This PR allows the `Pim\Bundle\CustomEntityBundle\Updater\Updater` to cache several metadata types at the same time; thus allowing to update different kinds of custom entities with the same `Updater` instance.