### PR TITLE
Remove deprecated front-end form validation

### DIFF
--- a/CHANGELOG-1.10.md
+++ b/CHANGELOG-1.10.md
@@ -1,4 +1,15 @@
-#1.10.8
+# 1.10.9
+
+## Bug fixes
+
+- Remove deprecated frontend form validation; ensure compatibility with PIM ~1.7.26
+
+## Beware
+
+As of PIM v1.7.26, `JsFormValidationBundle` is no longer used in the PIM. If you still want to use front-end validation for your Custom Entity forms,
+you can do so by requiring [fp/jsformvalidator-bundle](https://github.com/formapro/JsFormValidatorBundle) in your composer.json
+
+# 1.10.8
 
 ## Improvements
 

--- a/Resources/views/CustomEntity/form.html.twig
+++ b/Resources/views/CustomEntity/form.html.twig
@@ -4,7 +4,6 @@
 {% oro_title_set({ params: { ('%title%'): title } }) %}
 
 {% block content %}
-    {{ JSFV(form) }}
     {{ form_start(form, {
         'action': formAction,
         'attr': {

--- a/Resources/views/CustomEntity/quickcreate.html.twig
+++ b/Resources/views/CustomEntity/quickcreate.html.twig
@@ -14,8 +14,6 @@
     }
 }) }}
 
-    {{ JSFV(form) }}
-
     {{ elements.form_errors(form) }}
 
     <div class="row-fluid">


### PR DESCRIPTION
As of PIM v1.7.26, the composer dependency for [fp/jsformvalidator-bundle](https://github.com/Abhoryo/APYJsFormValidationBundle) has been removed because this bundle is deprecated