### PR TITLE
Fixed quick export

### DIFF
--- a/Resources/config/actions.yml
+++ b/Resources/config/actions.yml
@@ -45,7 +45,7 @@ services:
             - '@pim_custom_entity.action_event_manager'
             - '@pim_custom_entity.manager.registry'
             - '@router'
-            - '@translator'
+            - '@translator.default'
             - '@pim_datagrid.extension.mass_action.dispatcher'
             - '@akeneo_batch.job.job_instance_repository'
             - '@akeneo_batch.launcher.simple_job_launcher'


### PR DESCRIPTION
"Argument 5 passed to Pim\Bundle\CustomEntityBundle\Action\AbstractAction::__construct() must implement interface Symfony\Contracts\Translation\TranslatorInterface, instance of Akeneo\Platform\Bundle\UIBundle\Translator\TranslatorDecorator given"